### PR TITLE
[#40][feature] 노드 생성 기능 - 노드 엔티티 구현

### DIFF
--- a/pintree/src/main/java/com/trio/pintree/login/domain/Children.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/Children.java
@@ -1,0 +1,26 @@
+package com.trio.pintree.login.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Children {
+
+    @Id @GeneratedValue
+    @Column(name = "children_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "parent_id")
+    private Node parent;
+
+    @ManyToOne
+    @JoinColumn(name = "child_id")
+    private Node child;
+
+}

--- a/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
@@ -21,10 +21,13 @@ public class Node {
     private Long id;
 
     @Column(name = "is_main")
-    private boolean isMain;
+    private boolean isMain = false;
 
     @Column(name = "is_up")
-    private boolean isUp;
+    private boolean isUp = true;
+
+    @Column(name = "is_official")
+    private boolean isOfficial = false;
 
     @Column(name = "node_index")
     private long index;
@@ -32,8 +35,6 @@ public class Node {
     @Column(name = "node_memo")
     private String memo;
 
-    @Column(name = "is_official")
-    private boolean isOfficial;
 
     @OneToOne(mappedBy = "child")
     private ParentChild parent;
@@ -48,12 +49,17 @@ public class Node {
         this.isOfficial = isOfficial;
     }
 
-    public static Node createMainNode(boolean isUp, long index, boolean isOfficial) {
-        return new Node(false, isUp, index, isOfficial);
+    public static Node createMainNode(long index, boolean isOfficial) {
+        final boolean isMain = true;
+        final boolean isUp = true;
+
+        return new Node(isMain, isUp, index, isOfficial);
     }
 
     public static Node createNonMainNode(Node parent, boolean isUp, long index, boolean isOfficial) {
-        Node node = new Node(false, isUp, index, isOfficial);
+        final boolean isMain = false;
+
+        Node node = new Node(isMain, isUp, index, isOfficial);
         ParentChild parentChild = ParentChild.create(parent, node);
         parent.addChild(parentChild);
         node.addParent(parentChild);

--- a/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
@@ -3,18 +3,20 @@ package com.trio.pintree.login.domain;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 @Entity
 @Getter
+@Table(name = "node")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Node {
 
-    @Id @GeneratedValue
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "node_id")
     private Long id;
 
@@ -25,7 +27,7 @@ public class Node {
     private boolean isUp;
 
     @Column(name = "node_index")
-    private int index;
+    private long index;
 
     @Column(name = "node_memo")
     private String memo;
@@ -39,9 +41,45 @@ public class Node {
     @OneToMany(mappedBy = "child", cascade = CascadeType.ALL)
     private List<ParentChild> children = new ArrayList<>();
 
+    private Node(boolean isMain, boolean isUp, long index, boolean isOfficial) {
+        this.isMain = isMain;
+        this.isUp = isUp;
+        this.index = index;
+        this.isOfficial = isOfficial;
+    }
 
-    @OneToMany(mappedBy = "child")
-    private List<Children> children = new ArrayList<>();
+    public static Node createMainNode(boolean isUp, long index, boolean isOfficial) {
+        return new Node(false, isUp, index, isOfficial);
+    }
 
+    public static Node createNonMainNode(Node parent, boolean isUp, long index, boolean isOfficial) {
+        Node node = new Node(false, isUp, index, isOfficial);
+        ParentChild parentChild = ParentChild.create(parent, node);
+        parent.addChild(parentChild);
+        node.addParent(parentChild);
+
+        return node;
+    }
+
+    private void addChild(ParentChild parentChild) {
+        children.add(parentChild);
+    }
+
+    private void addParent(ParentChild parentChild) {
+        this.parent = parentChild;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Node node = (Node) o;
+        return id.equals(node.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }
 

--- a/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
@@ -33,8 +33,12 @@ public class Node {
     @Column(name = "is_official")
     private boolean isOfficial;
 
-    @OneToMany(mappedBy = "parent")
-    private List<Children> parent = new ArrayList<>();
+    @OneToOne(mappedBy = "parent")
+    private ParentChild parent;
+
+    @OneToMany(mappedBy = "child", cascade = CascadeType.ALL)
+    private List<ParentChild> children = new ArrayList<>();
+
 
     @OneToMany(mappedBy = "child")
     private List<Children> children = new ArrayList<>();

--- a/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
@@ -35,10 +35,10 @@ public class Node {
     @Column(name = "is_official")
     private boolean isOfficial;
 
-    @OneToOne(mappedBy = "parent")
+    @OneToOne(mappedBy = "child")
     private ParentChild parent;
 
-    @OneToMany(mappedBy = "child", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL)
     private List<ParentChild> children = new ArrayList<>();
 
     private Node(boolean isMain, boolean isUp, long index, boolean isOfficial) {
@@ -57,7 +57,6 @@ public class Node {
         ParentChild parentChild = ParentChild.create(parent, node);
         parent.addChild(parentChild);
         node.addParent(parentChild);
-
         return node;
     }
 

--- a/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/Node.java
@@ -1,0 +1,43 @@
+package com.trio.pintree.login.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Node {
+
+    @Id @GeneratedValue
+    @Column(name = "node_id")
+    private Long id;
+
+    @Column(name = "is_main")
+    private boolean isMain;
+
+    @Column(name = "is_up")
+    private boolean isUp;
+
+    @Column(name = "node_index")
+    private int index;
+
+    @Column(name = "node_memo")
+    private String memo;
+
+    @Column(name = "is_official")
+    private boolean isOfficial;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Children> parent = new ArrayList<>();
+
+    @OneToMany(mappedBy = "child")
+    private List<Children> children = new ArrayList<>();
+
+}
+

--- a/pintree/src/main/java/com/trio/pintree/login/domain/ParentChild.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/ParentChild.java
@@ -5,9 +5,11 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.Objects;
 
 @Entity
 @Getter
+@Table(name = "parent_child")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ParentChild {
 
@@ -24,4 +26,25 @@ public class ParentChild {
     @JoinColumn(name = "child_id")
     private Node child;
 
+    private ParentChild(Node parent, Node child) {
+        this.parent = parent;
+        this.child = child;
+    }
+
+    public static ParentChild create(Node parent, Node child) {
+        return new ParentChild(parent, child);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ParentChild that = (ParentChild) o;
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
+    }
 }

--- a/pintree/src/main/java/com/trio/pintree/login/domain/ParentChild.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/ParentChild.java
@@ -9,10 +9,11 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Children {
+public class ParentChild {
 
-    @Id @GeneratedValue
-    @Column(name = "children_id")
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "parent_child_id")
     private Long id;
 
     @ManyToOne

--- a/pintree/src/main/java/com/trio/pintree/login/domain/ParentChild.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/ParentChild.java
@@ -16,7 +16,7 @@ public class ParentChild {
     @Column(name = "parent_child_id")
     private Long id;
 
-    @ManyToOne
+    @OneToOne
     @JoinColumn(name = "parent_id")
     private Node parent;
 

--- a/pintree/src/main/java/com/trio/pintree/login/repository/NodeRepository.java
+++ b/pintree/src/main/java/com/trio/pintree/login/repository/NodeRepository.java
@@ -1,0 +1,7 @@
+package com.trio.pintree.login.repository;
+
+import com.trio.pintree.login.domain.Node;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NodeRepository extends JpaRepository<Node, Long> {
+}

--- a/pintree/src/test/java/com/trio/pintree/login/domain/NodeTest.java
+++ b/pintree/src/test/java/com/trio/pintree/login/domain/NodeTest.java
@@ -1,0 +1,47 @@
+package com.trio.pintree.login.domain;
+
+import com.trio.pintree.login.repository.NodeRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class NodeTest {
+
+    @Autowired
+    private NodeRepository repository;
+
+    @Test
+    void 메인노드를_생성할_수_있다() throws Exception {
+        boolean isUp = true;
+        long index = 100L;
+        boolean isOfficial = false;
+
+        Node node = Node.createMainNode(isUp, index, isOfficial);
+
+        repository.save(node);
+
+        Node savedNode = repository.getById(node.getId());
+        assertThat(savedNode).isEqualTo(node);
+    }
+    
+    @Test
+    void 자식노드를_생성할_수_있다() throws Exception {
+        boolean isUp = true;
+        boolean isDown = false;
+        long index = 100L;
+        boolean isOfficial = false;
+
+        Node parent = Node.createMainNode(isUp, index, isOfficial);
+        Node firstChild = Node.createNonMainNode(parent, isUp, index, isOfficial);
+        Node secondChild = Node.createNonMainNode(parent, isDown, index, isOfficial);
+
+        repository.save(parent);
+
+        Node savedNode = repository.getById(parent.getId());
+        assertThat(savedNode.getChildren()).hasSize(2);
+    }
+
+}

--- a/pintree/src/test/java/com/trio/pintree/login/domain/NodeTest.java
+++ b/pintree/src/test/java/com/trio/pintree/login/domain/NodeTest.java
@@ -15,11 +15,10 @@ class NodeTest {
 
     @Test
     void 메인노드를_생성할_수_있다() throws Exception {
-        boolean isUp = true;
         long index = 100L;
         boolean isOfficial = false;
 
-        Node node = Node.createMainNode(isUp, index, isOfficial);
+        Node node = Node.createMainNode(index, isOfficial);
 
         repository.save(node);
 
@@ -34,7 +33,7 @@ class NodeTest {
         long index = 100L;
         boolean isOfficial = false;
 
-        Node parent = Node.createMainNode(isUp, index, isOfficial);
+        Node parent = Node.createMainNode(index, isOfficial);
         Node firstChild = Node.createNonMainNode(parent, isUp, index, isOfficial);
         Node secondChild = Node.createNonMainNode(parent, isDown, index, isOfficial);
 


### PR DESCRIPTION
**Node 엔티티**와 노드 간 parent-child 관계를 나타내는 **ParentChild 엔티티**를 구현했습니다

> 관계 테이블과 매핑되는 **ParentChild 엔티티**의 네이밍은 변경가능합니다. 
> 추천하실만한 이름이 있다면 코멘트 남겨주세요!

-----

### 고민 되었던 부분 : parent와 child 연관관계
- Node 엔티티에서 parent 필드와 child 필드는 어떤 매핑을 해야 좋을지 고민했습니다
- 그리고 제가 내린 결론은 아래와 같아요
```java
public class Node { // ...
    // child는 하나의 parent를 가진다
    @OneToOne(mappedBy = "parent")
    private ParentChild parent;

    // parent는 여러 개의 child를 가진다
    @OneToMany(mappedBy = "child", cascade = CascadeType.ALL)
    private List<ParentChild> children = new ArrayList<>();
  ```


![image](https://user-images.githubusercontent.com/74452069/134646477-1bf6acd7-bff5-4b9d-96ed-b3a05cff5373.png)

### 고민 되었던 부분 : Enum 적용

> 참고 : https://fir-screen-46c.notion.site/Main-position-6aef5e2fa54040ce9cd6d8abc34eca43

- Enum(EnumType.STRING)을 적용하게 되면 DB 상에서는 varchar(255) 타입으로 관리가 됩니다(mysql에서는)
- 아무래도 우리 서비스에서는 노드의 생성이 많아질 것이기 때문에 **enum을 필수적으로 적용할 필요가 없고**, **option이 2가지밖에 없는 경우**라면 boolean 타입으로 관리하는 것이 더 효율적일 것 같아요!

- 이런 관점에서, enum을 사용하지 않아도 될 것 같은 부분이 아래 두 가지라고 생각했습니다
> 1. 현재 노드가 Main인지 여부(MAIN/NONMAIN)
>     - 메인과 메인이 아닌 노드 이외에 다른 옵션을 따로 추가할 예정이 아니라면 boolean으로 변경해도 좋을 것 같아요
> 2. 노드의 Position(UP/DOWN)
>     - 노드의 위치 정보가 up과 down 이외의 다른 옵션을 추가할 필요가 없다면 마찬가지로 boolean으로 변경해도 좋을 것 같습니다

- 그래서 현재 코드에서는 해당 부분을 boolean 타입으로 관리하고 있습니다! 만약 모두 괜찮다고 말씀해주시면 API 문서에도 반영하겠습니당


-----


#### 혹시 틀렸다고 생각하시거나 피드백 주실 부분이 있다면 언제든 환영입니다~~!!
#### 읽어주셔서 감사합니다아🙇‍♀️
