### PR TITLE
[#39][feature] 로드맵 공개 여부

### DIFF
--- a/pintree/src/main/java/com/trio/pintree/login/domain/Member.java
+++ b/pintree/src/main/java/com/trio/pintree/login/domain/Member.java
@@ -1,6 +1,5 @@
 package com.trio.pintree.login.domain;
 
-import com.trio.pintree.login.dto.oauth.UserProfile;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +10,7 @@ import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import java.util.Objects;
 import java.util.UUID;
 
 
@@ -37,5 +37,18 @@ public class Member {
 
     public static Member create(String email, String nickname, String profileUrl) {
         return new Member(email, nickname, profileUrl);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Member)) return false;
+        Member member = (Member) o;
+        return id.equals(member.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/pintree/src/main/java/com/trio/pintree/roadmap/domain/RoadMap.java
+++ b/pintree/src/main/java/com/trio/pintree/roadmap/domain/RoadMap.java
@@ -24,10 +24,6 @@ public class RoadMap {
     @Column(name = "is_public")
     private Boolean isPublic = false;
 
-    private double progress = 0.0;
-
-    private String shareUrl = "";
-
     private RoadMap(String title) {
         this.title = title;
     }

--- a/pintree/src/main/java/com/trio/pintree/roadmap/domain/RoadMap.java
+++ b/pintree/src/main/java/com/trio/pintree/roadmap/domain/RoadMap.java
@@ -22,7 +22,7 @@ public class RoadMap {
     private String title;
 
     @Column(name = "is_public")
-    private Boolean isPublic = false;
+    private boolean isPublic = false;
 
     private RoadMap(String title) {
         this.title = title;

--- a/pintree/src/main/java/com/trio/pintree/roadmap/domain/RoadMap.java
+++ b/pintree/src/main/java/com/trio/pintree/roadmap/domain/RoadMap.java
@@ -21,6 +21,9 @@ public class RoadMap {
     @Column(name = "roadmap_title")
     private String title;
 
+    @Column(name = "is_public")
+    private Boolean isPublic = false;
+
     private double progress = 0.0;
 
     private String shareUrl = "";
@@ -31,5 +34,17 @@ public class RoadMap {
 
     public static RoadMap from(String title) {
         return new RoadMap(title);
+    }
+
+    public void setPublic() {
+        this.isPublic = true;
+    }
+
+    public void setPrivate() {
+        this.isPublic = false;
+    }
+
+    public boolean isPublic() {
+        return isPublic;
     }
 }

--- a/pintree/src/main/java/com/trio/pintree/roadmap/dto/RoadMapDto.java
+++ b/pintree/src/main/java/com/trio/pintree/roadmap/dto/RoadMapDto.java
@@ -1,0 +1,16 @@
+package com.trio.pintree.roadmap.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RoadMapDto {
+    private Long roadMapId;
+
+    public RoadMapDto(Long roadMapId) {
+        this.roadMapId = roadMapId;
+    }
+
+    public static RoadMapDto from(Long roadMapId) {
+        return new RoadMapDto(roadMapId);
+    }
+}

--- a/pintree/src/main/java/com/trio/pintree/roadmap/service/RoadMapService.java
+++ b/pintree/src/main/java/com/trio/pintree/roadmap/service/RoadMapService.java
@@ -1,0 +1,30 @@
+package com.trio.pintree.roadmap.service;
+
+import com.trio.pintree.roadmap.domain.RoadMap;
+import com.trio.pintree.roadmap.dto.RoadMapDto;
+import com.trio.pintree.roadmap.exception.NotFoundRoadMapException;
+import com.trio.pintree.roadmap.repository.RoadMapRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+
+@Service
+@RequiredArgsConstructor
+public class RoadMapService {
+
+    private final RoadMapRepository roadMapRepository;
+
+    public boolean setRoadMapPublic(RoadMapDto roadMapDto) {
+        RoadMap roadMap = roadMapRepository.findById(roadMapDto.getRoadMapId())
+                .orElseThrow(NotFoundRoadMapException::new);
+        roadMap.setPublic();
+        return roadMap.isPublic();
+    }
+
+    public boolean setRoadMapPrivate(RoadMapDto roadMapDto) {
+        RoadMap roadMap = roadMapRepository.findById(roadMapDto.getRoadMapId())
+                .orElseThrow(NotFoundRoadMapException::new);
+        roadMap.setPrivate();
+        return roadMap.isPublic();
+    }
+}

--- a/pintree/src/test/java/com/trio/pintree/roadmap/domain/RoadMapTest.java
+++ b/pintree/src/test/java/com/trio/pintree/roadmap/domain/RoadMapTest.java
@@ -76,4 +76,45 @@ class RoadMapTest {
         //then
         assertThat(violations.size()).isEqualTo(1);
     }
+
+    @Test
+    @DisplayName("로드맵의 공개여부 기본값은 비공개이다.")
+    void itShouldSetDefaultToPrivate() {
+        //given
+        String title = "제목1";
+
+        //when
+        RoadMap roadMap = RoadMap.from(title);
+
+        //then
+        assertThat(roadMap.isPublic()).isFalse();
+    }
+
+    @Test
+    @DisplayName("로드맵은 공개여부를 공개로 설정할 수 있다.")
+    void itShouldSetPublic() {
+        //given
+        String title = "제목1";
+
+        //when
+        RoadMap roadMap = RoadMap.from(title);
+        roadMap.setPublic();
+
+        //then
+        assertThat(roadMap.isPublic()).isTrue();
+    }
+
+    @Test
+    @DisplayName("로드맵은 공개여부를 비공개로 설정할 수 있다.")
+    void itShouldSetPrivate() {
+        //given
+        String title = "제목1";
+
+        //when
+        RoadMap roadMap = RoadMap.from(title);
+        roadMap.setPrivate();
+
+        //then
+        assertThat(roadMap.isPublic()).isFalse();
+    }
 }

--- a/pintree/src/test/java/com/trio/pintree/roadmap/service/RoadMapServiceTest.java
+++ b/pintree/src/test/java/com/trio/pintree/roadmap/service/RoadMapServiceTest.java
@@ -1,0 +1,59 @@
+package com.trio.pintree.roadmap.service;
+
+import com.trio.pintree.roadmap.domain.RoadMap;
+import com.trio.pintree.roadmap.dto.RoadMapDto;
+import com.trio.pintree.roadmap.repository.RoadMapRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+
+@ExtendWith(MockitoExtension.class)
+class RoadMapServiceTest {
+
+    private RoadMapService roadMapService;
+    private RoadMapRepository roadMapRepository;
+
+    @BeforeEach
+    void setUp() {
+        roadMapRepository = mock(RoadMapRepository.class);
+        roadMapService = new RoadMapService(roadMapRepository);
+    }
+
+    @Test
+    @DisplayName("공개여부를 공개로 변경할 수 있다.")
+    void itShouldModifyToPublic() {
+        //given
+        RoadMap roadMap = RoadMap.from("제목1");
+        RoadMapDto roadMapDto = RoadMapDto.from(1L);
+        when(roadMapRepository.findById(roadMapDto.getRoadMapId())).thenReturn(Optional.of(roadMap));
+
+        //when
+        boolean result = roadMapService.setRoadMapPublic(roadMapDto);
+
+        //then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("공개여부를 비공개로 변경할 수 있다.")
+    void itShouldModifyToPrivate() {
+        //given
+        RoadMap roadMap = RoadMap.from("제목1");
+        RoadMapDto roadMapDto = RoadMapDto.from(1L);
+        when(roadMapRepository.findById(roadMapDto.getRoadMapId())).thenReturn(Optional.of(roadMap));
+
+        //when
+        boolean result = roadMapService.setRoadMapPrivate(roadMapDto);
+
+        //then
+        assertThat(result).isFalse();
+    }
+}


### PR DESCRIPTION
안녕하세요 쿠퍼입니다 🤨
다시 한번 코드 리뷰를 요청하기 위해 나타났습니다 😈
기존의 요구 사항에서는 `작성자에 한해서 공개여부가 가능`하지만 현재 단계에서 `세션값을 통해 유저를 조회하는 기능`이 별도로 존재하지 않습니다ㅠ
그래서 `세션을 통한 멤버 조회`를 별도 issue를 발급하고 요구사항에 맞는 내용을 구현하는 것이 맞다고 판단하여 공개 여부 기능만 구현하여 PR 드립니다.
이번에 첫 mock객체를 사용한 테스트 코드를 작성해보았는데 조언해주실 부분있으면 거침없는 피드백 부탁드립니다.
다시 한번 바쁜 시간내어 코드리뷰 해주셔서 감사합니다. 🧑‍💻
